### PR TITLE
Add Mockito agent config and mock helpers for validator tests

### DIFF
--- a/ITConference/pom.xml
+++ b/ITConference/pom.xml
@@ -27,6 +27,7 @@
     </scm>
     <properties>
         <java.version>17</java.version>
+        <mockito.version>5.11.0</mockito.version>
     </properties>
     <dependencies>
         <dependency>
@@ -110,6 +111,14 @@
                     </goals>
                 </execution>
             </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <argLine>-javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/ITConference/src/test/java/validator/BeamerCheckValidatorTest.java
+++ b/ITConference/src/test/java/validator/BeamerCheckValidatorTest.java
@@ -1,0 +1,55 @@
+package validator;
+
+import domain.Event;
+import domain.Lokaal;
+import domain.Spreker;
+import jakarta.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+public class BeamerCheckValidatorTest {
+
+    private ConstraintValidatorContext mockContext() {
+        ConstraintValidatorContext ctx = mock(ConstraintValidatorContext.class);
+        ConstraintValidatorContext.ConstraintViolationBuilder builder = mock(ConstraintValidatorContext.ConstraintViolationBuilder.class);
+        ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext node = mock(ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext.class);
+        when(ctx.buildConstraintViolationWithTemplate(anyString())).thenReturn(builder);
+        when(builder.addPropertyNode(anyString())).thenReturn(node);
+        when(node.addConstraintViolation()).thenReturn(ctx);
+        return ctx;
+    }
+
+    private Event createEvent(int beamercode, int beamercheck) {
+        Event event = new Event("Test", "desc",
+                List.of(new Spreker("Jan")),
+                new Lokaal("A101", 30),
+                LocalDateTime.of(2025, 6, 1, 10, 0),
+                beamercode,
+                new BigDecimal("10.00"));
+        event.setBeamercheck(beamercheck);
+        return event;
+    }
+
+    @Test
+    void returnsTrueWhenBeamercheckMatches() {
+        Event event = createEvent(1234, 1234 % 97);
+        BeamerCheckValidator validator = new BeamerCheckValidator();
+        boolean result = validator.isValid(event, mockContext());
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void returnsFalseWhenBeamercheckDoesNotMatch() {
+        Event event = createEvent(1234, 1);
+        BeamerCheckValidator validator = new BeamerCheckValidator();
+        boolean result = validator.isValid(event, mockContext());
+        assertThat(result).isFalse();
+    }
+}

--- a/ITConference/src/test/java/validator/ConferenceDateValidatorTest.java
+++ b/ITConference/src/test/java/validator/ConferenceDateValidatorTest.java
@@ -1,0 +1,62 @@
+package validator;
+
+import jakarta.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class ConferenceDateValidatorTest {
+
+    private ConferenceDateValidator validator;
+
+    private ConstraintValidatorContext mockContext() {
+        ConstraintValidatorContext ctx = mock(ConstraintValidatorContext.class);
+        ConstraintValidatorContext.ConstraintViolationBuilder builder = mock(ConstraintValidatorContext.ConstraintViolationBuilder.class);
+        ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext node = mock(ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext.class);
+        when(ctx.buildConstraintViolationWithTemplate(anyString())).thenReturn(builder);
+        when(builder.addPropertyNode(anyString())).thenReturn(node);
+        when(node.addConstraintViolation()).thenReturn(ctx);
+        return ctx;
+    }
+
+    static class Dummy {
+        @ValidConferenceDate(startDate = "2025-05-18", endDate = "2025-12-31")
+        LocalDateTime value;
+    }
+
+    @BeforeEach
+    void setUp() throws NoSuchFieldException {
+        validator = new ConferenceDateValidator();
+        ValidConferenceDate annotation = Dummy.class.getDeclaredField("value")
+                .getAnnotation(ValidConferenceDate.class);
+        validator.initialize(annotation);
+    }
+
+    @Test
+    void allowsNullValues() {
+        assertThat(validator.isValid(null, mockContext())).isTrue();
+    }
+
+    @Test
+    void returnsTrueForDateWithinPeriod() {
+        LocalDateTime date = LocalDateTime.of(2025, 6, 1, 10, 0);
+        assertThat(validator.isValid(date, mockContext())).isTrue();
+    }
+
+    @Test
+    void returnsFalseForDateBeforePeriod() {
+        LocalDateTime date = LocalDateTime.of(2025, 5, 1, 10, 0);
+        assertThat(validator.isValid(date, mockContext())).isFalse();
+    }
+
+    @Test
+    void returnsFalseForDateAfterPeriod() {
+        LocalDateTime date = LocalDateTime.of(2026, 1, 1, 10, 0);
+        assertThat(validator.isValid(date, mockContext())).isFalse();
+    }
+}

--- a/ITConference/src/test/java/validator/EventConstraintsValidatorTest.java
+++ b/ITConference/src/test/java/validator/EventConstraintsValidatorTest.java
@@ -1,0 +1,115 @@
+package validator;
+
+import domain.Event;
+import domain.Lokaal;
+import domain.Spreker;
+import jakarta.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import repository.EventRepository;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class EventConstraintsValidatorTest {
+
+    private EventRepository repository;
+    private ConstraintValidatorContext context;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(EventRepository.class);
+        context = mockContext();
+    }
+
+    private ConstraintValidatorContext mockContext() {
+        ConstraintValidatorContext ctx = mock(ConstraintValidatorContext.class);
+        ConstraintValidatorContext.ConstraintViolationBuilder builder = mock(ConstraintValidatorContext.ConstraintViolationBuilder.class);
+        ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext node = mock(ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext.class);
+        when(ctx.buildConstraintViolationWithTemplate(anyString())).thenReturn(builder);
+        when(builder.addPropertyNode(anyString())).thenReturn(node);
+        when(node.addConstraintViolation()).thenReturn(ctx);
+        return ctx;
+    }
+
+    private Event createEvent(Long id, String naam, LocalDateTime datumTijd, Lokaal lokaal) {
+        Event event = new Event(naam, "desc", List.of(new Spreker("Jan")), lokaal, datumTijd, 1234, new BigDecimal("10.00"));
+        event.setBeamercheck(event.calculateCorrectBeamerCheck());
+        event.setId(id);
+        return event;
+    }
+
+    @Test
+    void returnsFalseWhenRepositoryNotInjected() {
+        EventConstraintsValidator validator = new EventConstraintsValidator();
+        Event event = createEvent(null, "Test", LocalDateTime.now(), new Lokaal("A101", 30));
+        assertThat(validator.isValid(event, context)).isFalse();
+    }
+
+    @Test
+    void returnsTrueWhenNoDuplicatesFound() {
+        when(repository.findByDatumTijdAndLokaal(any(LocalDateTime.class), any(Lokaal.class)))
+                .thenReturn(Collections.emptyList());
+        when(repository.findByNaamAndDatum(anyString(), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+
+        EventConstraintsValidator validator = new EventConstraintsValidator();
+        validator.setEventRepository(repository);
+
+        Event event = createEvent(1L, "Test", LocalDateTime.of(2025,6,1,10,0), new Lokaal("A101", 30));
+        assertThat(validator.isValid(event, context)).isTrue();
+    }
+
+    @Test
+    void returnsFalseWhenDuplicateTimeAndLocationFound() {
+        Event duplicate = createEvent(2L, "Dup", LocalDateTime.of(2025,6,1,10,0), new Lokaal("A101", 30));
+        when(repository.findByDatumTijdAndLokaal(any(LocalDateTime.class), any(Lokaal.class)))
+                .thenReturn(List.of(duplicate));
+        when(repository.findByNaamAndDatum(anyString(), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+
+        EventConstraintsValidator validator = new EventConstraintsValidator();
+        validator.setEventRepository(repository);
+
+        Event event = createEvent(1L, "Test", LocalDateTime.of(2025,6,1,10,0), new Lokaal("A101", 30));
+        assertThat(validator.isValid(event, context)).isFalse();
+    }
+
+    @Test
+    void returnsFalseWhenDuplicateNameAndDateFound() {
+        Event duplicate = createEvent(2L, "Test", LocalDateTime.of(2025,6,1,10,0), new Lokaal("B202", 30));
+        when(repository.findByDatumTijdAndLokaal(any(LocalDateTime.class), any(Lokaal.class)))
+                .thenReturn(Collections.emptyList());
+        when(repository.findByNaamAndDatum(anyString(), any(LocalDate.class)))
+                .thenReturn(List.of(duplicate));
+
+        EventConstraintsValidator validator = new EventConstraintsValidator();
+        validator.setEventRepository(repository);
+
+        Event event = createEvent(1L, "Test", LocalDateTime.of(2025,6,1,10,0), new Lokaal("A101", 30));
+        assertThat(validator.isValid(event, context)).isFalse();
+    }
+
+    @Test
+    void ignoresDuplicatesWithSameId() {
+        Event same = createEvent(1L, "Test", LocalDateTime.of(2025,6,1,10,0), new Lokaal("A101", 30));
+        when(repository.findByDatumTijdAndLokaal(any(LocalDateTime.class), any(Lokaal.class)))
+                .thenReturn(List.of(same));
+        when(repository.findByNaamAndDatum(anyString(), any(LocalDate.class)))
+                .thenReturn(List.of(same));
+
+        EventConstraintsValidator validator = new EventConstraintsValidator();
+        validator.setEventRepository(repository);
+
+        Event event = createEvent(1L, "Test", LocalDateTime.of(2025,6,1,10,0), new Lokaal("A101", 30));
+        assertThat(validator.isValid(event, context)).isTrue();
+    }
+}

--- a/ITConference/src/test/java/validator/SpeakerListValidatorTest.java
+++ b/ITConference/src/test/java/validator/SpeakerListValidatorTest.java
@@ -1,0 +1,41 @@
+package validator;
+
+import domain.Spreker;
+import jakarta.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class SpeakerListValidatorTest {
+
+    private final SpeakerListValidator validator = new SpeakerListValidator();
+
+    @Test
+    void returnsTrueWhenListIsNull() {
+        assertThat(validator.isValid(null, mock(ConstraintValidatorContext.class))).isTrue();
+    }
+
+    @Test
+    void returnsTrueForUniqueSpeakers() {
+        List<Spreker> list = List.of(new Spreker("A"), new Spreker("B"));
+        assertThat(validator.isValid(list, mock(ConstraintValidatorContext.class))).isTrue();
+    }
+
+    @Test
+    void returnsFalseForDuplicateSpeakers() {
+        Spreker s = new Spreker("A");
+        List<Spreker> list = List.of(s, s);
+        assertThat(validator.isValid(list, mock(ConstraintValidatorContext.class))).isFalse();
+    }
+
+    @Test
+    void returnsFalseForNullElement() {
+        List<Spreker> list = new ArrayList<>(Arrays.asList(new Spreker("A"), null));
+        assertThat(validator.isValid(list, mock(ConstraintValidatorContext.class))).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- fully mock `ConstraintValidatorContext` in validator tests
- ensure speaker list test allows `null` elements
- run Mockito via Java agent in Maven Surefire plugin

## Testing
- `./mvnw -q test` *(fails to download Maven)*