### PR TITLE
Clean unused message keys

### DIFF
--- a/ITConference/src/main/resources/i18n/messages.properties
+++ b/ITConference/src/main/resources/i18n/messages.properties
@@ -71,22 +71,12 @@ eventAdd.title=Add Event
 eventAdd.header=Add New Event
 eventAdd.submitButton=Add Event
 
-event.add.title=Add Event
-event.add.header=Add New Event
-event.add.submitButton=Add Event
 event.add.success=Event successfully added!
 
 # ========================================
 # Event Edit
 # ========================================
-eventEdit.title=Edit Event
-eventEdit.header=Edit Event
-eventEdit.submitButton=Save Event
 
-event.edit.title=Edit Event
-event.edit.header=Edit Event
-event.edit.submitButton=Update Event
-event.edit.button.title=Edit event
 event.edit.success=Event successfully updated!
 eventDetail.editButton=Edit Event
 
@@ -98,10 +88,6 @@ eventRemove.header=Delete Event
 eventRemove.confirmMessage=Are you sure you want to delete the event?
 eventRemove.deleteButton=Delete
 
-event.remove.title=Delete Event
-event.remove.header=Delete Event
-event.remove.confirmMessage=Are you sure you want to delete {0}?
-event.remove.deleteButton=Delete
 event.delete.success=Event successfully deleted!
 
 # ========================================
@@ -191,10 +177,6 @@ lokaal.edit.success=Location successfully updated!
 lokaal.delete.success=Location successfully deleted!
 lokaal.delete.error.hasEvents=Cannot delete location: {0}
 lokaal.delete.error.has_linked_events=Cannot delete location. There are still events linked to this location.
-lokaal.remove.title=Delete Location
-lokaal.remove.header=Delete Location
-lokaal.remove.confirmMessage=Are you sure you want to delete location {0}?
-lokaal.remove.deleteButton=Delete
 lokaal.notfound=Room with name {0} was not found.
 
 # ========================================
@@ -208,8 +190,6 @@ favoritesOverview.noFavorites=You don't have any favorite events yet.
 # ========================================
 # Favorite Add/Remove Messages
 # ========================================
-favorite.add.title=Add to favorites
-favorite.remove.title=Remove from favorites
 favorite.add.success=Event successfully added to favorites.
 favorite.add.error=Could not add event to favorites: {0}
 favorite.remove.success=Event successfully removed from favorites.
@@ -222,8 +202,6 @@ favorite.max_reached=You have reached the maximum of {0} favorite events.
 toast.success.title=Successful
 toast.error.title=Error
 toast.close=Close
-toastTitleError=Error
-toastTitleSuccess=Success
 
 # ========================================
 lokaalRemove.title=Delete Room

--- a/ITConference/src/main/resources/i18n/messages_nl.properties
+++ b/ITConference/src/main/resources/i18n/messages_nl.properties
@@ -71,22 +71,12 @@ eventAdd.title=Evenement Toevoegen
 eventAdd.header=Nieuw Evenement Toevoegen
 eventAdd.submitButton=Evenement Toevoegen
 
-event.add.title=Evenement Toevoegen
-event.add.header=Nieuw Evenement Toevoegen
-event.add.submitButton=Evenement Toevoegen
 event.add.success=Evenement succesvol toegevoegd!
 
 # ========================================
 # Evenement Bewerken
 # ========================================
-eventEdit.title=Evenement Bewerken
-eventEdit.header=Evenement Bewerken
-eventEdit.submitButton=Evenement Opslaan
 
-event.edit.title=Evenement Bewerken
-event.edit.header=Evenement Bewerken
-event.edit.submitButton=Evenement Bijwerken
-event.edit.button.title=Evenement Bewerken
 event.edit.success=Evenement succesvol bijgewerkt!
 eventDetail.editButton=Evenement Bewerken
 
@@ -98,10 +88,6 @@ eventRemove.header=Evenement Verwijderen
 eventRemove.confirmMessage=Weet je zeker dat je het evenement wilt verwijderen?
 eventRemove.deleteButton=Verwijderen
 
-event.remove.title=Evenement Verwijderen
-event.remove.header=Evenement Verwijderen
-event.remove.confirmMessage=Weet je zeker dat je {0} wilt verwijderen?
-event.remove.deleteButton=Verwijderen
 event.delete.success=Evenement succesvol verwijderd!
 
 # ========================================
@@ -191,10 +177,6 @@ lokaal.edit.success=Locatie succesvol bijgewerkt!
 lokaal.delete.success=Locatie succesvol verwijderd!
 lokaal.delete.error.hasEvents=Kan locatie niet verwijderen: {0}
 lokaal.delete.error.has_linked_events=Kan locatie niet verwijderen. Er zijn nog evenementen gekoppeld aan deze locatie.
-lokaal.remove.title=Locatie Verwijderen
-lokaal.remove.header=Locatie Verwijderen
-lokaal.remove.confirmMessage=Weet je zeker dat je locatie {0} wilt verwijderen?
-lokaal.remove.deleteButton=Verwijderen
 lokaal.notfound=Lokaal met naam {0} niet gevonden.
 
 # ========================================
@@ -208,8 +190,6 @@ favoritesOverview.noFavorites=Je hebt nog geen favoriete evenementen.
 # ========================================
 # Favoriet Toevoegen/Verwijderen Meldingen
 # ========================================
-favorite.add.title=Toevoegen aan favorieten
-favorite.remove.title=Verwijderen uit favorieten
 favorite.add.success=Evenement succesvol toegevoegd aan favorieten.
 favorite.add.error=Kon evenement niet toevoegen aan favorieten: {0}
 favorite.remove.success=Evenement succesvol verwijderd uit favorieten.
@@ -222,8 +202,6 @@ favorite.max_reached=Je hebt het maximum van {0} favoriete evenementen bereikt.
 toast.success.title=Succesvol
 toast.error.title=Fout
 toast.close=Sluiten
-toastTitleSuccess=Succesvol
-toastTitleError=Fout
 
 lokaalRemove.title=Verwijder Lokaal
 lokaalRemove.header=Verwijder Lokaal


### PR DESCRIPTION
## Summary
- delete unused and duplicate message keys
- keep only the keys referenced by templates and controllers

## Testing
- `./mvnw test -q` *(fails: Failed to fetch Maven binaries)*