### PR TITLE
Fix EventTest date validation by using fixed clock

### DIFF
--- a/ITConference/src/test/java/com/hogent/ewdj/itconference/domain/EventTest.java
+++ b/ITConference/src/test/java/com/hogent/ewdj/itconference/domain/EventTest.java
@@ -15,6 +15,8 @@ import validator.EventConstraintsValidator;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Clock;
+import java.time.ZoneOffset;
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -61,6 +63,10 @@ public class EventTest {
 
         Configuration<?> config = Validation.byDefaultProvider().configure();
         config.constraintValidatorFactory(new InjectingConstraintValidatorFactory(repo));
+        config.clockProvider(() -> Clock.fixed(
+                LocalDateTime.of(2025, 5, 18, 0, 0)
+                        .toInstant(ZoneOffset.UTC),
+                ZoneOffset.UTC));
         ValidatorFactory factory = config.buildValidatorFactory();
         validator = factory.getValidator();
     }


### PR DESCRIPTION
## Summary
- ensure Event validation tests use a fixed clock

## Testing
- `./mvnw -q test` *(fails: unable to fetch Maven)*

------
https://chatgpt.com/codex/tasks/task_b_68403d3f7fd483318cc31d4418d0579e